### PR TITLE
Fix empty params and Multisig actor

### DIFF
--- a/src/builtin/account/mod.rs
+++ b/src/builtin/account/mod.rs
@@ -4,7 +4,7 @@
 mod state;
 
 pub use self::state::State;
-use crate::{builtin::singletons::SYSTEM_ACTOR_ADDR, check_empty_params};
+use crate::builtin::singletons::SYSTEM_ACTOR_ADDR;
 use address::{Address, Protocol};
 use ipld_blockstore::BlockStore;
 use num_derive::FromPrimitive;
@@ -71,7 +71,6 @@ impl ActorCode for Actor {
                 Ok(Serialized::default())
             }
             Some(Method::PubkeyAddress) => {
-                check_empty_params(params)?;
                 let addr = Self::pubkey_address(rt)?;
                 Ok(Serialized::serialize(addr)?)
             }

--- a/src/builtin/cron/mod.rs
+++ b/src/builtin/cron/mod.rs
@@ -4,7 +4,7 @@
 mod state;
 
 pub use self::state::{Entry, State};
-use crate::{check_empty_params, SYSTEM_ACTOR_ADDR};
+use crate::SYSTEM_ACTOR_ADDR;
 use encoding::tuple::*;
 use ipld_blockstore::BlockStore;
 use num_derive::FromPrimitive;
@@ -87,7 +87,6 @@ impl ActorCode for Actor {
                 Ok(Serialized::default())
             }
             Some(Method::EpochTick) => {
-                check_empty_params(params)?;
                 Self::epoch_tick(rt)?;
                 Ok(Serialized::default())
             }

--- a/src/builtin/market/mod.rs
+++ b/src/builtin/market/mod.rs
@@ -11,7 +11,7 @@ use self::policy::*;
 pub use self::state::*;
 pub use self::types::*;
 use crate::{
-    check_empty_params, make_map, power, request_miner_control_addrs, reward,
+    make_map, power, request_miner_control_addrs, reward,
     verifreg::{Method as VerifregMethod, RestoreBytesParams, UseBytesParams},
     ActorDowncast, DealID, SetMultimap, BURNT_FUNDS_ACTOR_ADDR, CALLER_TYPES_SIGNABLE,
     CRON_ACTOR_ADDR, MINER_ACTOR_CODE_ID, REWARD_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR,
@@ -1236,7 +1236,6 @@ impl ActorCode for Actor {
     {
         match FromPrimitive::from_u64(method) {
             Some(Method::Constructor) => {
-                check_empty_params(params)?;
                 Self::constructor(rt)?;
                 Ok(Serialized::default())
             }
@@ -1269,7 +1268,6 @@ impl ActorCode for Actor {
                 Ok(Serialized::serialize(res)?)
             }
             Some(Method::CronTick) => {
-                check_empty_params(params)?;
                 Self::cron_tick(rt)?;
                 Ok(Serialized::default())
             }

--- a/src/builtin/miner/mod.rs
+++ b/src/builtin/miner/mod.rs
@@ -36,9 +36,9 @@ use crate::{
     power::MAX_MINER_PROVE_COMMITS_PER_EPOCH,
 };
 use crate::{
-    check_empty_params, is_principal, make_map, smooth::FilterEstimate, ACCOUNT_ACTOR_CODE_ID,
-    BURNT_FUNDS_ACTOR_ADDR, CALLER_TYPES_SIGNABLE, INIT_ACTOR_ADDR, REWARD_ACTOR_ADDR,
-    STORAGE_MARKET_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR,
+    is_principal, make_map, smooth::FilterEstimate, ACCOUNT_ACTOR_CODE_ID, BURNT_FUNDS_ACTOR_ADDR,
+    CALLER_TYPES_SIGNABLE, INIT_ACTOR_ADDR, REWARD_ACTOR_ADDR, STORAGE_MARKET_ACTOR_ADDR,
+    STORAGE_POWER_ACTOR_ADDR,
 };
 use crate::{
     market::{
@@ -3846,7 +3846,6 @@ impl ActorCode for Actor {
                 Ok(Serialized::default())
             }
             Some(Method::ControlAddresses) => {
-                check_empty_params(params)?;
                 let res = Self::control_addresses(rt)?;
                 Ok(Serialized::serialize(&res)?)
             }
@@ -3923,12 +3922,10 @@ impl ActorCode for Actor {
                 Ok(Serialized::default())
             }
             Some(Method::ConfirmUpdateWorkerKey) => {
-                check_empty_params(params)?;
                 Self::confirm_update_worker_key(rt)?;
                 Ok(Serialized::default())
             }
             Some(Method::RepayDebt) => {
-                check_empty_params(params)?;
                 Self::repay_debt(rt)?;
                 Ok(Serialized::default())
             }

--- a/src/builtin/paych/mod.rs
+++ b/src/builtin/paych/mod.rs
@@ -6,10 +6,7 @@ mod types;
 
 pub use self::state::{LaneState, Merge, State};
 pub use self::types::*;
-use crate::{
-    check_empty_params, resolve_to_id_addr, ActorDowncast, ACCOUNT_ACTOR_CODE_ID,
-    INIT_ACTOR_CODE_ID,
-};
+use crate::{resolve_to_id_addr, ActorDowncast, ACCOUNT_ACTOR_CODE_ID, INIT_ACTOR_CODE_ID};
 use address::Address;
 use ipld_amt::Amt;
 use ipld_blockstore::BlockStore;
@@ -370,12 +367,10 @@ impl ActorCode for Actor {
                 Ok(Serialized::default())
             }
             Some(Method::Settle) => {
-                check_empty_params(params)?;
                 Self::settle(rt)?;
                 Ok(Serialized::default())
             }
             Some(Method::Collect) => {
-                check_empty_params(params)?;
                 Self::collect(rt)?;
                 Ok(Serialized::default())
             }

--- a/src/builtin/power/mod.rs
+++ b/src/builtin/power/mod.rs
@@ -11,9 +11,8 @@ pub use self::types::*;
 use crate::miner::MinerConstructorParams;
 use crate::reward::Method as RewardMethod;
 use crate::{
-    check_empty_params, init, make_map, make_map_with_root, miner, ActorDowncast, Multimap,
-    CALLER_TYPES_SIGNABLE, CRON_ACTOR_ADDR, INIT_ACTOR_ADDR, MINER_ACTOR_CODE_ID,
-    REWARD_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
+    init, make_map, make_map_with_root, miner, ActorDowncast, Multimap, CALLER_TYPES_SIGNABLE,
+    CRON_ACTOR_ADDR, INIT_ACTOR_ADDR, MINER_ACTOR_CODE_ID, REWARD_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
 };
 use address::Address;
 use ahash::AHashSet;
@@ -597,7 +596,6 @@ impl ActorCode for Actor {
     {
         match FromPrimitive::from_u64(method) {
             Some(Method::Constructor) => {
-                check_empty_params(params)?;
                 Self::constructor(rt)?;
                 Ok(Serialized::default())
             }
@@ -614,7 +612,6 @@ impl ActorCode for Actor {
                 Ok(Serialized::default())
             }
             Some(Method::OnEpochTickEnd) => {
-                check_empty_params(params)?;
                 Self::on_epoch_tick_end(rt)?;
                 Ok(Serialized::default())
             }
@@ -628,7 +625,6 @@ impl ActorCode for Actor {
                 Ok(Serialized::default())
             }
             Some(Method::CurrentTotalPower) => {
-                check_empty_params(params)?;
                 let res = Self::current_total_power(rt)?;
                 Ok(Serialized::serialize(res)?)
             }

--- a/src/builtin/reward/mod.rs
+++ b/src/builtin/reward/mod.rs
@@ -10,9 +10,7 @@ pub use self::logic::*;
 pub use self::state::{Reward, State, VestingFunction};
 pub use self::types::*;
 use crate::network::EXPECTED_LEADERS_PER_EPOCH;
-use crate::{
-    check_empty_params, miner, BURNT_FUNDS_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
-};
+use crate::{miner, BURNT_FUNDS_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR};
 use fil_types::StoragePower;
 use ipld_blockstore::BlockStore;
 use num_bigint::Sign;
@@ -258,7 +256,6 @@ impl ActorCode for Actor {
                 Ok(Serialized::default())
             }
             Some(Method::ThisEpochReward) => {
-                check_empty_params(params)?;
                 let res = Self::this_epoch_reward(rt)?;
                 Ok(Serialized::serialize(&res)?)
             }

--- a/src/builtin/system/mod.rs
+++ b/src/builtin/system/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use crate::{check_empty_params, SYSTEM_ACTOR_ADDR};
+use crate::SYSTEM_ACTOR_ADDR;
 
 use encoding::Cbor;
 use ipld_blockstore::BlockStore;
@@ -46,7 +46,7 @@ impl ActorCode for Actor {
     fn invoke_method<BS, RT>(
         rt: &mut RT,
         method: MethodNum,
-        params: &Serialized,
+        _params: &Serialized,
     ) -> Result<Serialized, ActorError>
     where
         BS: BlockStore,
@@ -54,7 +54,6 @@ impl ActorCode for Actor {
     {
         match FromPrimitive::from_u64(method) {
             Some(Method::Constructor) => {
-                check_empty_params(params)?;
                 Self::constructor(rt)?;
                 Ok(Serialized::default())
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,16 +33,6 @@ pub type Map<'bs, BS, V> = Hamt<'bs, BS, V, BytesKey>;
 /// Deal weight
 pub type DealWeight = BigInt;
 
-/// Used when invocation requires parameters to be an empty array of bytes
-pub fn check_empty_params(params: &Serialized) -> Result<(), ActorError> {
-    if !params.is_empty() {
-        Err(actor_error!(ErrSerialization;
-                "params expected to be empty, was: {}", base64::encode(params.bytes())))
-    } else {
-        Ok(())
-    }
-}
-
 /// Create a hamt configured with constant bit width.
 #[inline]
 pub fn make_map<BS, V>(store: &'_ BS) -> Map<'_, BS, V>


### PR DESCRIPTION
Non-empty params sent to a method with no params should not fail. 
Multisig actor was not handling deleting properly.
These two issues caused 2 forks. This fixes that and we are syncing again!
WIll cut a release after this gets merged. 